### PR TITLE
Compute `LAST_RELEASED_HZ_VERSION_OSS` in `get-hz-versions` using `master` script

### DIFF
--- a/.github/workflows/test-get-hz-versions.yml
+++ b/.github/workflows/test-get-hz-versions.yml
@@ -30,12 +30,18 @@ jobs:
             local msg="$name should be equal to $expected"
             assert_eq "$expected" "$actual" "$msg" && log_success "$msg" || TESTS_RESULT=$?
           }
+
+          assert_populated() {
+            local name=$1
+            local actual=$2
+            local msg="$name should not be empty"
+            assert_not_empty "$actual" "$msg" && log_success "$msg" || TESTS_RESULT=$?
+          }
           
           EXPECTED_OSS="1.2.4"
-          EXPECTED_OSS_LAST_RELEASED="1.2.2"
           EXPECTED_EE="1.2.3"
           assert_equals "HZ_VERSION_OSS" "$EXPECTED_OSS" "${{ steps.hz_versions.outputs.HZ_VERSION_OSS }}"
-          assert_equals "LAST_RELEASED_HZ_VERSION_OSS" "$EXPECTED_OSS_LAST_RELEASED" "${{ steps.hz_versions.outputs.LAST_RELEASED_HZ_VERSION_OSS }}"
+          assert_populated "LAST_RELEASED_HZ_VERSION_OSS" "${{ steps.hz_versions.outputs.LAST_RELEASED_HZ_VERSION_OSS }}"
           assert_equals "HZ_VERSION_EE" "$EXPECTED_EE" "${{ steps.hz_versions.outputs.HZ_VERSION_EE }}"
 
           assert_eq 0 "$TESTS_RESULT" "All tests should pass"

--- a/get-hz-versions/action.yml
+++ b/get-hz-versions/action.yml
@@ -30,7 +30,8 @@ runs:
         HZ_VERSION_OSS=$(awk -F '=' '/^ARG HZ_VERSION=/ {print $2}' hazelcast-oss/Dockerfile)
         echo "HZ_VERSION_OSS=$HZ_VERSION_OSS" >> $GITHUB_OUTPUT
 
-        source hazelcast-oss/maven.functions.sh
+        source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/master/hazelcast-oss/maven.functions.sh)"
+
         LAST_RELEASED_HZ_VERSION_OSS="$(get_latest_version com.hazelcast hazelcast-distribution https://repo1.maven.org/maven2)"
         echo "LAST_RELEASED_HZ_VERSION_OSS=$LAST_RELEASED_HZ_VERSION_OSS" >> $GITHUB_OUTPUT
 

--- a/get-hz-versions/action.yml
+++ b/get-hz-versions/action.yml
@@ -31,7 +31,6 @@ runs:
         echo "HZ_VERSION_OSS=$HZ_VERSION_OSS" >> $GITHUB_OUTPUT
 
         source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/master/hazelcast-oss/maven.functions.sh)"
-
         LAST_RELEASED_HZ_VERSION_OSS="$(get_latest_version com.hazelcast hazelcast-distribution https://repo1.maven.org/maven2)"
         echo "LAST_RELEASED_HZ_VERSION_OSS=$LAST_RELEASED_HZ_VERSION_OSS" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
The [`5.4.z` variant of `maven.functions.sh`](https://github.com/hazelcast/hazelcast-docker/blob/5.4.z/hazelcast-oss/maven.functions.sh) requires `xmllint`, which is why it's [specifically installed](https://github.com/hazelcast/hazelcast-docker/blob/43024230bb73104e9b54f46dd2d31177337a322a/.github/actions/install-xmllint/action.yml).

However - the `docker-actions` variant has no such knowledge, but still calls the script from the _source_ branch, even though the design of `docker-actions` is to avoid using multiple versions of the same script.

Ideally, we'd migrate that script to `docker-actions`, but we need the script to be in the `hazelcast-docker` repo, _next to the `Dockerfile`_, to support a simple `docker build` experience.

As such the next-best-thing is to `source` the script from the `master` branch of `hazelcast-docker`, rather than the branch-under-test.