### PR TITLE
Simplify `get-hz-versions` output

### DIFF
--- a/.github/scripts/logging.functions.sh
+++ b/.github/scripts/logging.functions.sh
@@ -1,0 +1,4 @@
+# Delegate to "hazelcast-docker" implementation
+
+# Source the latest version of assert.sh unit testing library and include in current shell
+source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/master/.github/scripts/logging.functions.sh)"

--- a/.github/workflows/test-get-hz-versions.yml
+++ b/.github/workflows/test-get-hz-versions.yml
@@ -38,10 +38,7 @@ jobs:
             assert_not_empty "$actual" "$msg" && log_success "$msg" || TESTS_RESULT=$?
           }
           
-          EXPECTED_OSS="1.2.4"
-          EXPECTED_EE="1.2.3"
-          assert_equals "HZ_VERSION_OSS" "$EXPECTED_OSS" "${{ steps.hz_versions.outputs.HZ_VERSION_OSS }}"
+          assert_equals "HZ_VERSION" "1.2.3" "${{ steps.hz_versions.outputs.HZ_VERSION }}"
           assert_populated "LAST_RELEASED_HZ_VERSION_OSS" "${{ steps.hz_versions.outputs.LAST_RELEASED_HZ_VERSION_OSS }}"
-          assert_equals "HZ_VERSION_EE" "$EXPECTED_EE" "${{ steps.hz_versions.outputs.HZ_VERSION_EE }}"
 
           assert_eq 0 "$TESTS_RESULT" "All tests should pass"

--- a/get-hz-versions/README.md
+++ b/get-hz-versions/README.md
@@ -12,9 +12,8 @@ A GitHub Action that extracts Hazelcast OSS and EE version information from Dock
 
 | Name                         | Description                                                 |
 |------------------------------|-------------------------------------------------------------|
-| HZ_VERSION_OSS               | Hazelcast OSS version from `hazelcast-oss/Dockerfile`       |
+| HZ_VERSION                   | Hazelcast version from the `Dockerfile`                     |
 | LAST_RELEASED_HZ_VERSION_OSS | Latest released Hazelcast OSS version from Maven Central    |
-| HZ_VERSION_EE                | Hazelcast EE version from `hazelcast-enterprise/Dockerfile` |
 
 ## Usage
 
@@ -28,5 +27,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: hazelcast/docker-actions/get-hz-versions@master
         id: hz_versions
-      - run: echo "OSS Version: ${{ steps.hz_versions.outputs.HZ_VERSION_OSS }}"
+      - run: echo "HZ Version: ${{ steps.hz_versions.outputs.HZ_VERSION }}"
 ```

--- a/get-hz-versions/action.yml
+++ b/get-hz-versions/action.yml
@@ -9,15 +9,12 @@ inputs:
     default: .
 
 outputs:
-  HZ_VERSION_OSS:
-    description: Hazelcast OSS version
-    value: ${{ steps.get_docker_vars.outputs.HZ_VERSION_OSS }}
+  HZ_VERSION:
+    description: Hazelcast version
+    value: ${{ steps.get_docker_vars.outputs.HZ_VERSION }}
   LAST_RELEASED_HZ_VERSION_OSS:
     description: Last released Hazelcast OSS version
     value: ${{ steps.get_maven_vars.outputs.LAST_RELEASED_HZ_VERSION_OSS }}
-  HZ_VERSION_EE:
-    description: Hazelcast EE version
-    value: ${{ steps.get_docker_vars.outputs.HZ_VERSION_EE }}
 
 runs:
   using: "composite"
@@ -27,13 +24,22 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
+        source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/master/.github/scripts/logging.functions.sh)"
+
         get_hz_version() {
           local dockerfile=$1
           awk -F '=' '/^ARG HZ_VERSION=/ {print $2}' ${dockerfile}
         }
 
-        echo "HZ_VERSION_OSS=$(get_hz_version hazelcast-oss/Dockerfile)" >> ${GITHUB_OUTPUT}
-        echo "HZ_VERSION_EE=$(get_hz_version hazelcast-enterprise/Dockerfile)" >> ${GITHUB_OUTPUT}
+        HZ_VERSION_OSS=$(get_hz_version hazelcast-oss/Dockerfile)
+        HZ_VERSION_EE=$(get_hz_version hazelcast-enterprise/Dockerfile)
+
+        if [[ ${HZ_VERSION_OSS} == ${HZ_VERSION_EE} ]]; then
+          echo "HZ_VERSION=${HZ_VERSION_OSS}" >> ${GITHUB_OUTPUT}
+        else
+          echoerr "Versions extracted from Dockerfile(s) do not match (${HZ_VERSION_OSS} / ${HZ_VERSION_EE})!"
+          exit 1
+        fi
 
     - name: Get Maven variables
       id: get_maven_vars

--- a/get-hz-versions/action.yml
+++ b/get-hz-versions/action.yml
@@ -24,7 +24,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/master/.github/scripts/logging.functions.sh)"
+        . ${{ github.action_path }}/../.github/scripts/logging.functions.sh
 
         get_hz_version() {
           local dockerfile=$1

--- a/get-hz-versions/action.yml
+++ b/get-hz-versions/action.yml
@@ -34,7 +34,7 @@ runs:
         HZ_VERSION_OSS=$(get_hz_version hazelcast-oss/Dockerfile)
         HZ_VERSION_EE=$(get_hz_version hazelcast-enterprise/Dockerfile)
 
-        if [[ ${HZ_VERSION_OSS} == ${HZ_VERSION_EE} ]]; then
+        if [[ "${HZ_VERSION_OSS}" == "${HZ_VERSION_EE}"]]; then
           echo "HZ_VERSION=${HZ_VERSION_OSS}" >> ${GITHUB_OUTPUT}
         else
           echoerr "Versions extracted from Dockerfile(s) do not match (${HZ_VERSION_OSS} / ${HZ_VERSION_EE})!"

--- a/get-hz-versions/action.yml
+++ b/get-hz-versions/action.yml
@@ -34,7 +34,7 @@ runs:
         HZ_VERSION_OSS=$(get_hz_version hazelcast-oss/Dockerfile)
         HZ_VERSION_EE=$(get_hz_version hazelcast-enterprise/Dockerfile)
 
-        if [[ "${HZ_VERSION_OSS}" == "${HZ_VERSION_EE}"]]; then
+        if [[ "${HZ_VERSION_OSS}" == "${HZ_VERSION_EE}" ]]; then
           echo "HZ_VERSION=${HZ_VERSION_OSS}" >> ${GITHUB_OUTPUT}
         else
           echoerr "Versions extracted from Dockerfile(s) do not match (${HZ_VERSION_OSS} / ${HZ_VERSION_EE})!"

--- a/get-hz-versions/test-data/hazelcast-oss/Dockerfile
+++ b/get-hz-versions/test-data/hazelcast-oss/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3
 
-ARG HZ_VERSION=1.2.4
+ARG HZ_VERSION=1.2.3
 
 ARG HZ_HOME="/opt/hazelcast"


### PR DESCRIPTION
`get-hz-versions` outputs both OS and EE versions, but both are always in sync. Moreover, this gets confusing [in release workflows - if the `RELEASE_TYPE` is `ALL`, it just uses the EE version for both anyway](https://github.com/hazelcast/hazelcast-docker/blob/f396fb79365347fe76ae204ba285386ab38b0474/.github/workflows/tag_image_push.yml#L69).

Instead there should be a single version.