### PR TITLE
Simplify Test Failure Collector

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  test-scripts:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
   test-get-hz-versions:
     uses: ./.github/workflows/test-get-hz-versions.yml
 
@@ -22,20 +16,3 @@ jobs:
 
   test-resolve-editions:
     uses: ./.github/workflows/test-resolve-editions.yml
-
-  assert-all-jobs-succeeded:
-    runs-on: ubuntu-latest
-    needs:
-      - test-get-hz-versions
-      - test-slack-notification
-      - test-get-supported-jdks
-    if: always()
-    steps:
-      - name: Check all jobs succeeded
-        run: |
-          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" || "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
-            echo "❌ Some jobs failed or were cancelled"
-            exit 1
-          else
-            echo "✅ All jobs completed successfully!"
-          fi


### PR DESCRIPTION
`test.yml` has a `assert-all-jobs-succeeded` `job` that `needs` all the _other_ tests and prints a message if any fail.

This requires each new test to be _manually_ added as a prerequisite, and not all are (e.g. `test-resolve-editions`).

Moreover, it's not neccesary - if any `jobs` fail, it's reported on the PR ([example execution](https://github.com/hazelcast/docker-actions/actions/runs/17309794934/job/49141400897?pr=10)):
<img width="747" height="415" alt="image" src="https://github.com/user-attachments/assets/cd34b880-6ff0-4234-85eb-c6eca9aa65c0" />

_If_ we had branch protection and we wanted a specific, named `job` to pass, then I could see the value - but we don't.