### PR TITLE
Migrate `check-base-images`

### DIFF
--- a/.github/scripts/logging.functions.sh
+++ b/.github/scripts/logging.functions.sh
@@ -1,0 +1,4 @@
+# Delegate to "hazelcast-docker" implementation
+
+# Source the latest version of assert.sh unit testing library and include in current shell
+source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/master/.github/scripts/logging.functions.sh)"

--- a/.github/workflows/test-check-base-images.yml
+++ b/.github/workflows/test-check-base-images.yml
@@ -1,0 +1,52 @@
+name: Test check-base-images action
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Test scripts
+        run: ./check-base-images/test_scripts.sh
+
+      - name: Run check-base-images OSS
+        id: check-base-images-oss
+        uses: ./check-base-images
+        with:
+          ref: v5.0.1
+          image-name: hazelcast/hazelcast:5.0.1-slim
+          dockerfile-path: hazelcast/Dockerfile
+
+      - name: Run check-base-images EE
+        id: check-base-images-ee
+        uses: ./check-base-images
+        with:
+          ref: v5.0.1
+          image-name: hazelcast/hazelcast-enterprise:5.0.1-slim
+          dockerfile-path: hazelcast-enterprise/Dockerfile
+
+      - name: Test
+        run: |
+          set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
+          source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+
+          TESTS_RESULT=0
+          
+          assert_equals() {
+            local image=$1
+            local expected=$2
+            local actual=$3
+            local msg="Outdated for $image should be equal to $expected"
+            assert_eq "$expected" "$actual" "$msg" && log_success "$msg" || TESTS_RESULT=$?
+          }
+
+
+          assert_equals "hazelcast/hazelcast:5.0.1-slim" "true" "${{ steps.check-base-images-oss.outputs.outdated }}"
+          assert_equals "hazelcast/hazelcast-enterprise:5.0.1-slim" "true" "${{ steps.check-base-images-ee.outputs.outdated }}"
+
+          assert_eq 0 "$TESTS_RESULT" "All tests should pass"
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+  test-check-base-images:
+    uses: ./.github/workflows/test-check-base-images.yml
+
   test-get-hz-versions:
     uses: ./.github/workflows/test-get-hz-versions.yml
 
@@ -26,6 +29,7 @@ jobs:
   assert-all-jobs-succeeded:
     runs-on: ubuntu-latest
     needs:
+      - test-check-base-images
       - test-get-hz-versions
       - test-slack-notification
       - test-get-supported-jdks

--- a/check-base-images/action.yml
+++ b/check-base-images/action.yml
@@ -1,0 +1,47 @@
+name: Check base image outdated
+description: Check if the base image or system packages are outdated
+
+inputs:
+  ref:
+    description: hazelcast-docker branch to check
+    required: true
+  image-name:
+    description: Name of the image (e.g. hazelcast/hazelcast:5.5.0-slim)
+    required: true
+  dockerfile-path:
+    description: Path to the dockerfile (e.g. hazelcast-enterprise/Dockerfile)
+    required: true
+
+outputs:
+  outdated:
+    description: If the specified image is outdated
+    value: ${{ steps.check.outputs.outdated }}
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v5
+      with:
+        repository: hazelcast/hazelcast-docker
+        ref: ${{ inputs.ref }}
+        path: hazelcast-docker
+
+    - shell: bash
+      id: check
+      run: |
+        . ${{ github.action_path }}/check-base-images.functions.sh
+
+        image=${{ inputs.image-name }}
+        dockerfile=hazelcast-docker/${{ inputs.dockerfile-path }}
+
+        echodebug "Checking ${image}"
+        if base_image_outdated_from_dockerfile "${image}" "${dockerfile}"; then
+          echo "outdated=true" >> ${GITHUB_OUTPUT}
+          echonotice "${image} needs rebuild"
+        elif packages_updatable_from_dockerfile "${image}" "${dockerfile}"; then
+          echo "outdated=true" >> ${GITHUB_OUTPUT}
+          echonotice "System package upgrades for ${image} available"
+        else
+          echo "outdated=false" >> ${GITHUB_OUTPUT}
+          echodebug "${image} is up-to-date"
+        fi

--- a/check-base-images/check-base-images.functions.sh
+++ b/check-base-images/check-base-images.functions.sh
@@ -1,0 +1,82 @@
+source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/master/.github/scripts/logging.functions.sh)"
+
+# Determine if the packages in the specified image are updatable
+# Returns exit code:
+# 0 if the packages in the image are updatable
+# 1 if the packages in the image is up-to-date
+function packages_updatable_from_dockerfile() {
+  local image=$1
+  local dockerfile=$2
+
+  local base_image_name
+  base_image_name=$(get_base_image_name "${dockerfile}")
+  packages_updatable "${image}" "${base_image_name}"
+}
+
+# Determine if the packages in the specified image are updatable
+# Returns exit code:
+# 0 if the packages in the image are updatable
+# 1 if the packages in the image is up-to-date
+function packages_updatable() {
+  local image=$1
+  local base_image=$2
+
+  local output
+
+  if [[ "${base_image}" == *"alpine"* ]]; then
+    output=$(docker run --user 0 --rm "${image}" sh -c 'apk update >/dev/null && apk list --upgradeable')
+    echodebug "${output}"
+    [[ -n "${output}" ]]
+  elif [[ "${base_image}" == *"redhat/ubi"* ]]; then
+    # use assumeno as a workaround for lack of dry-run option
+    output=$(docker run --user 0 --rm "${image}" sh -c "microdnf --assumeno upgrade --nodocs")
+    echodebug "${output}"
+    local package_upgrades
+    package_upgrades=$(echo "${output}" | grep --count Upgrading)
+    [[ "${package_upgrades}" -ne 0 ]]
+  else
+    echoerr "Unsupported base image: ${base_image}"
+    exit 1
+  fi
+}
+
+# Returns the base image of the specified Dockerfile
+function get_base_image_name() {
+  local dockerfile=$1
+  # Read the (implicitly first) `FROM` line
+  grep '^FROM ' "${dockerfile}" | cut -d' ' -f2
+}
+
+# Determine if the specified image is outdated when compared to it's base image
+# Returns exit code:
+# 0 if the current image is outdated compared to the base image
+# 1 if the current image is up-to-date compared to the base image
+function base_image_outdated_from_dockerfile() {
+  local current_image=$1
+  local dockerfile=$2
+
+  local base_image_name
+  base_image_name=$(get_base_image_name "${dockerfile}")
+  base_image_outdated "${current_image}" "${base_image_name}"
+}
+
+# Determine if the specified image is outdated when compared to it's base image
+# Returns exit code:
+# 0 if the current image is outdated compared to the base image
+# 1 if the current image is up-to-date compared to the base image
+function base_image_outdated() {
+  local current_image=$1
+  local base_image=$2
+
+  local base_image_sha
+  base_image_sha=$(get_base_image_sha "${base_image}")
+  local current_image_sha
+  current_image_sha=$(get_base_image_sha "${current_image}")
+  [[ "${current_image_sha}" != "${base_image_sha}" ]]
+}
+
+function get_base_image_sha() {
+  local image=$1
+  docker pull "${image}" --quiet
+  docker image inspect --format '{{index .RootFS.Layers 0}}' "${image}"
+}

--- a/check-base-images/check-base-images.functions.sh
+++ b/check-base-images/check-base-images.functions.sh
@@ -77,6 +77,6 @@ function base_image_outdated() {
 
 function get_base_image_sha() {
   local image=$1
-  docker pull "${image}" --quiet
+  docker pull "${image}" >/dev/null
   docker image inspect --format '{{index .RootFS.Layers 0}}' "${image}"
 }

--- a/check-base-images/check-base-images.functions.sh
+++ b/check-base-images/check-base-images.functions.sh
@@ -1,4 +1,5 @@
-source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/master/.github/scripts/logging.functions.sh)"
+# shellcheck source=../.github/scripts/logging.functions.sh
+. .github/scripts/logging.functions.sh
 
 # Determine if the packages in the specified image are updatable
 # Returns exit code:

--- a/check-base-images/check-base-images.functions.sh
+++ b/check-base-images/check-base-images.functions.sh
@@ -32,8 +32,7 @@ function packages_updatable() {
     # use assumeno as a workaround for lack of dry-run option
     output=$(docker run --user 0 --rm "${image}" sh -c "microdnf --assumeno upgrade --nodocs")
     echodebug "${output}"
-    local package_upgrades_count
-    package_upgrades_count=$(echo "${output}" | grep --count Upgrading)
+    local package_upgrades_count=$(echo "${output}" | grep --count Upgrading)
     [[ "${package_upgrades_count}" -ne 0 ]]
   else
     echoerr "Unsupported base image: ${base_image}"

--- a/check-base-images/check-base-images.functions.sh
+++ b/check-base-images/check-base-images.functions.sh
@@ -32,9 +32,9 @@ function packages_updatable() {
     # use assumeno as a workaround for lack of dry-run option
     output=$(docker run --user 0 --rm "${image}" sh -c "microdnf --assumeno upgrade --nodocs")
     echodebug "${output}"
-    local package_upgrades
-    package_upgrades=$(echo "${output}" | grep --count Upgrading)
-    [[ "${package_upgrades}" -ne 0 ]]
+    local package_upgrades_count
+    package_upgrades_count=$(echo "${output}" | grep --count Upgrading)
+    [[ "${package_upgrades_count}" -ne 0 ]]
   else
     echoerr "Unsupported base image: ${base_image}"
     exit 1

--- a/check-base-images/check-base-images.functions_tests.sh
+++ b/check-base-images/check-base-images.functions_tests.sh
@@ -31,7 +31,6 @@ function assert_packages_updatable {
   assert_eq "${expected_exit_code}" "${actual_exit_code}" "${msg}" && log_success "${msg}" || TESTS_RESULT=$?
 }
 
-
 log_header "Tests for packages_updatable"
 assert_packages_updatable hazelcast/hazelcast:5.0.1-slim alpine:3.15.0  0
 assert_packages_updatable hazelcast/hazelcast-enterprise:5.0.1-slim redhat/ubi8-minimal:8.5 0

--- a/check-base-images/check-base-images.functions_tests.sh
+++ b/check-base-images/check-base-images.functions_tests.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -eu ${RUNNER_DEBUG:+-x}
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+# Source the latest version of assert.sh unit testing library and include in current shell
+source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+
+. "$SCRIPT_DIR"/check-base-images.functions.sh
+
+TESTS_RESULT=0
+
+
+function assert_base_image_outdated {
+  local current_image=$1
+  local base_image=$2
+  local expected_exit_code=$3
+  base_image_outdated "${current_image}" "${base_image}" && true
+  local actual_exit_code=$?
+  local msg="Expected exit code for \"${current_image}\" compared to \"${base_image}\""
+  assert_eq "${expected_exit_code}" "${actual_exit_code}" "${msg}" && log_success "${msg}" || TESTS_RESULT=$?
+}
+
+function assert_packages_updatable {
+  local image=$1
+  local base_image=$2
+  local expected_exit_code=$3
+  packages_updatable "${image}" "${base_image}" && true
+  local actual_exit_code=$?
+  local msg="Expected exit code for image \"${image}\""
+  assert_eq "${expected_exit_code}" "${actual_exit_code}" "${msg}" && log_success "${msg}" || TESTS_RESULT=$?
+}
+
+
+log_header "Tests for packages_updatable"
+assert_packages_updatable hazelcast/hazelcast:5.0.1-slim alpine:3.15.0  0
+assert_packages_updatable hazelcast/hazelcast-enterprise:5.0.1-slim redhat/ubi8-minimal:8.5 0
+# Cannot guarantee the latest upstream image is fully updated
+# assert_packages_updatable alpine:latest alpine:latest 1
+# assert_packages_updatable redhat/ubi9-minimal:latest redhat/ubi9-minimal:latest 1
+
+log_header "Tests for base_image_outdated"
+assert_base_image_outdated alpine:latest alpine:latest 1
+assert_base_image_outdated hazelcast/hazelcast:5.0.1-slim alpine:latest 0
+
+
+assert_eq 0 "$TESTS_RESULT" "All tests should pass"

--- a/check-base-images/check-base-images.functions_tests.sh
+++ b/check-base-images/check-base-images.functions_tests.sh
@@ -43,5 +43,4 @@ log_header "Tests for base_image_outdated"
 assert_base_image_outdated alpine:latest alpine:latest 1
 assert_base_image_outdated hazelcast/hazelcast:5.0.1-slim alpine:latest 0
 
-
 assert_eq 0 "$TESTS_RESULT" "All tests should pass"

--- a/check-base-images/check-base-images.functions_tests.sh
+++ b/check-base-images/check-base-images.functions_tests.sh
@@ -11,7 +11,6 @@ source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelca
 
 TESTS_RESULT=0
 
-
 function assert_base_image_outdated {
   local current_image=$1
   local base_image=$2

--- a/check-base-images/test_scripts.sh
+++ b/check-base-images/test_scripts.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+find "$SCRIPT_DIR" -name "*_tests.sh" -print0 | xargs -0 -n1 bash

--- a/get-hz-versions/test_scripts.sh
+++ b/get-hz-versions/test_scripts.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+find "$SCRIPT_DIR" -name "*_tests.sh" -print0 | xargs -0 -n1 bash


### PR DESCRIPTION
Changes:
- replace `packages_updatable_ee` / `packages_updatable_oss` variants with a single function that determines based on base image
- merge base image / package functions into single script as both have cross dependencies