### PR TITLE
Add missing jobs to `assert-all-jobs-succeeded`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,18 +4,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  test-scripts:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
   test-get-hz-versions:
     uses: ./.github/workflows/test-get-hz-versions.yml
-
-  test-slack-notification:
-    uses: ./.github/workflows/test-slack-notification.yml
-    secrets: inherit
 
   test-get-supported-jdks:
     uses: ./.github/workflows/test-get-supported-jdks.yml
@@ -23,12 +13,17 @@ jobs:
   test-resolve-editions:
     uses: ./.github/workflows/test-resolve-editions.yml
 
+  test-slack-notification:
+    uses: ./.github/workflows/test-slack-notification.yml
+    secrets: inherit
+
   assert-all-jobs-succeeded:
     runs-on: ubuntu-latest
     needs:
       - test-get-hz-versions
-      - test-slack-notification
       - test-get-supported-jdks
+      - test-resolve-editions
+      - test-slack-notification
     if: always()
     steps:
       - name: Check all jobs succeeded


### PR DESCRIPTION
As raised in https://github.com/hazelcast/docker-actions/pull/10, some jobs' statuses aren't blocking the `assert-all-jobs-succeeded` status.

Also:
- ordered them alphabetically to match the GitHub UI so it's easi_er_ to see whats missing
- removed the redundant `checkout`