### PR TITLE
Support Slack execution from alternate  `job`s

### DIFF
--- a/slack-notification/action.yml
+++ b/slack-notification/action.yml
@@ -7,6 +7,9 @@ inputs:
   slack-channel:
     description: Slack channel to send the notification to
     default: "#hazelcast-docker-notifications"
+  status:
+    description: The status to set, otherwise inherited from the enclosing job
+    required: false
 runs:
   using: "composite"
   steps:
@@ -14,7 +17,7 @@ runs:
       id: slack_notification
       with:
         fields: all
-        status: ${{ job.status }}
+        status: ${{ inputs.status || job.status }}
         channel: ${{ inputs.slack-channel }}
       env:
         SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}


### PR DESCRIPTION
The reported status is based on the `job` - but this means if the `job` is triggered by a `failure` in a _different_ job, it'll incorrectly report a `success` status - [example workflow](https://github.com/hazelcast/hazelcast-docker/actions/runs/17343254716/job/49239916992).

Instead, allow this to be overriden.