### PR TITLE
Fix `check-base-images`

### DIFF
--- a/check-base-images/action.yml
+++ b/check-base-images/action.yml
@@ -29,7 +29,10 @@ runs:
     - shell: bash
       id: check
       run: |
-        . ${{ github.action_path }}/check-base-images.functions.sh
+        . ${{ github.action_path }}/../.github/scripts/logging.functions.sh
+        pushd ${{ github.action_path }}/..
+          . check-base-images/check-base-images.functions.sh
+        popd
 
         image=${{ inputs.image-name }}
         dockerfile=hazelcast-docker/${{ inputs.dockerfile-path }}


### PR DESCRIPTION
[The action failed](https://github.com/hazelcast/hazelcast-docker/actions/runs/17394801287) because when executed from another repo, the default `working-directory` was different - which meant that the `source` failed:
https://github.com/hazelcast/docker-actions/blob/80a714422cf09b35801d47c082d062496c315260/check-base-images/check-base-images.functions.sh#L1-L2

Added a workaround with `pushd` / `popd` to avoid changing paths and then struggling to locate the `hazelcast-docker` directory.