### PR TITLE
Improve `check-base-images` logs (again)

### DIFF
--- a/check-base-images/check-base-images.functions.sh
+++ b/check-base-images/check-base-images.functions.sh
@@ -31,7 +31,6 @@ function packages_updatable() {
       echonotice "${output}"
       return 0
     else
-      echodebug "${output}"
       return 1
     fi
   elif [[ "${base_image}" == *"redhat/ubi"* ]]; then

--- a/check-base-images/check-base-images.functions.sh
+++ b/check-base-images/check-base-images.functions.sh
@@ -22,15 +22,17 @@ function packages_updatable() {
   local image=$1
   local base_image=$2
 
+  local log_header="Upgradeable packages output:"
   local output
 
   if [[ "${base_image}" == *"alpine"* ]]; then
     output=$(docker run --user 0 --rm "${image}" sh -c 'apk update >/dev/null && apk list --upgradeable')
 
     if [[ -n "${output}" ]]; then
-      echonotice "${output}"
+      echonotice "${log_header}" "${output}"
       return 0
     else
+      # Nothing to log
       return 1
     fi
   elif [[ "${base_image}" == *"redhat/ubi"* ]]; then
@@ -41,10 +43,10 @@ function packages_updatable() {
     package_upgrades_count=$(grep --count Upgrading <<< "${output}")
 
     if [[ "${package_upgrades_count}" -ne 0 ]]; then
-      echonotice "${output}"
+      echonotice "${log_header}" "${output}"
       return 0
     else
-      echodebug "${output}"
+      echodebug "${log_header}" "${output}"
       return 1
     fi
   else


### PR DESCRIPTION
Improvements following @nishaatr's [review](https://github.com/hazelcast/docker-actions/pull/17#pullrequestreview-3175894999).

> any need to log as `"${output}"` is empty? may be log message? e.g. `echodebug "There is no packages to upgrade"`

98133f86c4349f82ab985e97e2f6f69a8d37d390

> not sure how output looks but might be helpful to prepend e.g. "Found packages to upgrade: ${output}"

ebc5e628d81cd90a161c91ff0428d13c260f9290
