### PR TITLE
Remove `LAST_RELEASED_HZ_VERSION_OSS`

### DIFF
--- a/.github/workflows/test-get-hz-versions.yml
+++ b/.github/workflows/test-get-hz-versions.yml
@@ -39,6 +39,5 @@ jobs:
           }
           
           assert_equals "HZ_VERSION" "1.2.3" "${{ steps.hz_versions.outputs.HZ_VERSION }}"
-          assert_populated "LAST_RELEASED_HZ_VERSION_OSS" "${{ steps.hz_versions.outputs.LAST_RELEASED_HZ_VERSION_OSS }}"
 
           assert_eq 0 "$TESTS_RESULT" "All tests should pass"

--- a/get-hz-versions/README.md
+++ b/get-hz-versions/README.md
@@ -13,7 +13,6 @@ A GitHub Action that extracts Hazelcast OSS and EE version information from Dock
 | Name                         | Description                                                 |
 |------------------------------|-------------------------------------------------------------|
 | HZ_VERSION                   | Hazelcast version from the `Dockerfile`                     |
-| LAST_RELEASED_HZ_VERSION_OSS | Latest released Hazelcast OSS version from Maven Central    |
 
 ## Usage
 

--- a/get-hz-versions/action.yml
+++ b/get-hz-versions/action.yml
@@ -12,9 +12,6 @@ outputs:
   HZ_VERSION:
     description: Hazelcast version
     value: ${{ steps.get_docker_vars.outputs.HZ_VERSION }}
-  LAST_RELEASED_HZ_VERSION_OSS:
-    description: Last released Hazelcast OSS version
-    value: ${{ steps.get_maven_vars.outputs.LAST_RELEASED_HZ_VERSION_OSS }}
 
 runs:
   using: "composite"
@@ -40,12 +37,3 @@ runs:
           echoerr "Versions extracted from Dockerfile(s) do not match (${HZ_VERSION_OSS} / ${HZ_VERSION_EE})!"
           exit 1
         fi
-
-    - name: Get Maven variables
-      id: get_maven_vars
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-      run: |
-        source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/master/hazelcast-oss/maven.functions.sh)"
-        LAST_RELEASED_HZ_VERSION_OSS="$(get_latest_version com.hazelcast hazelcast-distribution https://repo.maven.apache.org/maven2)"
-        echo "LAST_RELEASED_HZ_VERSION_OSS=$LAST_RELEASED_HZ_VERSION_OSS" >> ${GITHUB_OUTPUT}

--- a/get-hz-versions/test-data/hazelcast-oss/maven.functions.sh
+++ b/get-hz-versions/test-data/hazelcast-oss/maven.functions.sh
@@ -1,3 +1,0 @@
-get_latest_version() {
-  echo "1.2.2"
-}


### PR DESCRIPTION
It's no longer needed since https://github.com/hazelcast/hazelcast-docker/pull/1104