### PR TITLE
Don't fail the build for RedHat error statuses

### DIFF
--- a/check-redhat-service-status/action.yml
+++ b/check-redhat-service-status/action.yml
@@ -14,5 +14,4 @@ runs:
           echoerr "❌ RedHat service status"
           echoerr "$(jq '.status' <<< ${STATUS})"
           echoerr "$(curl --silent https://status.redhat.com/api/v2/incidents/unresolved.json | jq)"
-          exit 1
         fi


### PR DESCRIPTION
https://github.com/hazelcast/docker-actions/pull/19 is blocked from merging by regular RedHat outages - this demonstrates that we should _log_ when theres an outage but we shouldn't fail the build as it's far too regular.