### PR TITLE
Harden `slack-notification` inputs

### DIFF
--- a/.github/workflows/test-slack-notification.yml
+++ b/.github/workflows/test-slack-notification.yml
@@ -5,13 +5,20 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
+    strategy:
+      matrix:
+        status:
+          - ''
+          - success
+          - failure
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Run action
+      - name: Run action (status="${{ matrix.status }}")
         uses: ./slack-notification
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK }}
           slack-channel: "#test-channel"
+          status: ${{ matrix.status }}

--- a/slack-notification/action.yml
+++ b/slack-notification/action.yml
@@ -15,7 +15,6 @@ runs:
     - id: compute
       shell: bash
       run: |
-        STATUS=${{ inputs.status || job.status }}
         echo "status=${STATUS}" >> ${GITHUB_OUTPUT}
 
         JOB_URL=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -25,6 +24,8 @@ runs:
         else
           echo "text=❌ \`${{ github.workflow }}\` (\`${{ github.workflow_ref }}\`) - ${STATUS}\n${JOB_URL}" >> ${GITHUB_OUTPUT}
         fi
+      env:
+        STATUS: ${{ inputs.status || job.status }}
 
     - uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
       with:


### PR DESCRIPTION
`slack-notification` inputs should not be used directly to avoid code injection.

Raised from [PR feedback](https://github.com/hazelcast/docker-actions/pull/54#discussion_r3079337049).