### PR TITLE
Support backticks in Slack action by using GitHub environment variables

### DIFF
--- a/slack-notification/action.yml
+++ b/slack-notification/action.yml
@@ -20,9 +20,9 @@ runs:
         JOB_URL=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
         if [[ "${STATUS}" == "success" ]]; then
-          echo "text=✅ \`${{ github.workflow }}\` (\`${{ github.workflow_ref }}\`)\n${JOB_URL}" >> ${GITHUB_OUTPUT}
+          echo "text=✅ \`${GITHUB_WORKFLOW}\` (\`${GITHUB_WORKFLOW_REF}\`)\n${JOB_URL}" >> ${GITHUB_OUTPUT}
         else
-          echo "text=❌ \`${{ github.workflow }}\` (\`${{ github.workflow_ref }}\`) - ${STATUS}\n${JOB_URL}" >> ${GITHUB_OUTPUT}
+          echo "text=❌ \`${GITHUB_WORKFLOW}\` (\`${GITHUB_WORKFLOW_REF}\`) - ${STATUS}\n${JOB_URL}" >> ${GITHUB_OUTPUT}
         fi
       env:
         STATUS: ${{ inputs.status || job.status }}


### PR DESCRIPTION
When the workflow name contains backticks, the message passed into Slack is not properly escaped and [it breaks](https://github.com/hazelcast/hazelcast-mono/actions/runs/24567657762/job/71831996343#step:12:31).

We can sidestep this whole issue by using GitHub environment variables.

I can't add a test for this scenario as the name is inherited from the test suite (`Test All`), but for debugging I changed this to validate it works.

Note the formatting still isn't "right" when rendered in Slack, but it does at least send a message instead of breaking.
