### PR TITLE
Use latest JFrog CLI

### DIFF
--- a/get-jfrog-credentials/action.yml
+++ b/get-jfrog-credentials/action.yml
@@ -46,3 +46,4 @@ runs:
         JF_URL: https://${{ steps.get-url.outputs.url }}
       with:
         oidc-provider-name: ${{ inputs.jfrog-oidc-provider-name }}
+        version: latest


### PR DESCRIPTION
If you don't specify latest, you get an old version.

See:
- https://github.com/jfrog/setup-jfrog-cli#setting-jfrog-cli-version
- https://github.com/jfrog/setup-jfrog-cli/issues/321

Specifically the current version doesn't support `jf api`.