### PR TITLE
Rescope AWS ARN from `secret` to `var`

### DIFF
--- a/.github/workflows/test-download-hz-dist.yml
+++ b/.github/workflows/test-download-hz-dist.yml
@@ -22,7 +22,7 @@ jobs:
         id: download
         with:
           repo-vars-as-json: "{\n  \"MAVEN_EE_RELEASE_REPO\": \"https://repository.hazelcast.com/release\",\n  \"MAVEN_OSS_RELEASE_REPO\": \" \"\n}"
-          aws-role-to-assume: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+          aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           distribution: "${{ matrix.distribution }}"
           hz_version: "5.0"
           classifier: "slim"
@@ -48,7 +48,7 @@ jobs:
         id: download
         with:
           repo-vars-as-json: "{\n  \"MAVEN_OSS_SNAPSHOT_REPO\": \"snapshot-internal::::https://repository.hazelcast.com/snapshot-internal\",\n  \"MAVEN_OSS_RELEASE_REPO\": \" \"\n}"
-          aws-role-to-assume: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+          aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           distribution: hazelcast
           hz_version: "5.6.1-SNAPSHOT"
           classifier: "slim"

--- a/.github/workflows/test-get-jfrog-credentials.yml
+++ b/.github/workflows/test-get-jfrog-credentials.yml
@@ -15,13 +15,13 @@ jobs:
         # Run it twice to ensure no env name collisions
       - uses: ./get-jfrog-credentials
         with:
-          aws-role-to-assume: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+          aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           jfrog-oidc-provider-name: ${{ github.repository_owner }}-snapshot-internal
 
       - uses: ./get-jfrog-credentials
         id: jfrog
         with:
-          aws-role-to-assume: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+          aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           jfrog-oidc-provider-name: ${{ github.repository_owner }}-snapshot-internal
 
       - name: Test

--- a/.github/workflows/test-setup-maven-snapshot-internal.yml
+++ b/.github/workflows/test-setup-maven-snapshot-internal.yml
@@ -14,4 +14,4 @@ jobs:
 
       - uses: ./setup-maven-snapshot-internal
         with:
-          aws-role-to-assume: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+          aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}


### PR DESCRIPTION
The name of the role isn't a `secret`, so storing at such means it's masked logs etc which makes debugging difficult. More specifically, authentication is handled via [OIDC](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws), on it's own the role does nothing.

Instead, it should be rescoped as a `var`.