### PR TITLE
Update `download-hz-dist` to support multiple repositories [DI-730]

### DIFF
--- a/.github/workflows/test-download-hz-dist.yml
+++ b/.github/workflows/test-download-hz-dist.yml
@@ -42,7 +42,7 @@ jobs:
           fi
 
           # https://stackoverflow.com/a/2001750
-          if ! tar -tzf ${{ steps.download.outputs.output_file }} > /dev/null; then
+          if ! tar --list --gzip --file ${{ steps.download.outputs.output_file }} > /dev/null; then
             echo "${{ steps.download.outputs.output_file }} not valid!"
             exit 1
           fi

--- a/.github/workflows/test-download-hz-dist.yml
+++ b/.github/workflows/test-download-hz-dist.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 jobs:
-  test-public:
+  test:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -13,6 +13,12 @@ jobs:
         distribution:
           - hazelcast
           - hazelcast-enterprise
+        version:
+          - 5.1
+          - 5.6.1-SNAPSHOT
+        classifier:
+          - slim
+          - ''
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -21,42 +27,22 @@ jobs:
         uses: ./download-hz-dist
         id: download
         with:
-          repo-vars-as-json: "{\n  \"MAVEN_EE_RELEASE_REPO\": \"https://repository.hazelcast.com/release\",\n  \"MAVEN_OSS_RELEASE_REPO\": \" \"\n}"
+          environment: live
           aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           distribution: "${{ matrix.distribution }}"
-          hz_version: "5.0"
+          hz_version: "${{ matrix.version }}"
           classifier: "slim"
           packaging: "tar.gz"
 
-      - name: Check file exists
+      - name: Check file downloaded from `${{ steps.download.outputs.download_url }}`
         run: |
           if [[ ! -f "${{ steps.download.outputs.output_file }}" ]]; then
             echo "${{ steps.download.outputs.output_file }} not found!"
             exit 1
           fi
 
-  test-private:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Download
-        uses: ./download-hz-dist
-        id: download
-        with:
-          repo-vars-as-json: "{\n  \"MAVEN_OSS_SNAPSHOT_REPO\": \"snapshot-internal::::https://repository.hazelcast.com/snapshot-internal\",\n  \"MAVEN_OSS_RELEASE_REPO\": \" \"\n}"
-          aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
-          distribution: hazelcast
-          hz_version: "5.6.1-SNAPSHOT"
-          classifier: "slim"
-          packaging: "tar.gz"
-
-      - name: Check file exists
-        run: |
-          if [[ ! -f "${{ steps.download.outputs.output_file }}" ]]; then
-            echo "${{ steps.download.outputs.output_file }} not found!"
+          # https://stackoverflow.com/a/2001750
+          if ! tar -tzf ${{ steps.download.outputs.output_file }} > /dev/null; then
+            echo "${{ steps.download.outputs.output_file }} not valid!"
             exit 1
           fi

--- a/download-hz-dist/action.yml
+++ b/download-hz-dist/action.yml
@@ -56,7 +56,8 @@ runs:
         )
             ;;
           *)
-            echoerr "Unsupported environment (${ENVIRONMENT})" ; exit 1
+            echoerr "Unsupported environment (${ENVIRONMENT})"
+            exit 1
             ;;
         esac
 

--- a/download-hz-dist/action.yml
+++ b/download-hz-dist/action.yml
@@ -1,7 +1,6 @@
 name: Download Hazelcast Distribution
 inputs:
-  repo-vars-as-json:
-    description: 'Repo Vars as JSON - not inherited in composite actions - see https://github.com/orgs/community/discussions/49689#discussioncomment-6398261'
+  environment:
     required: true
   aws-role-to-assume:
     description: 'AWS Role to assume for accessing secrets'
@@ -25,61 +24,55 @@ inputs:
     description: 'Path to the output file'
     required: false
 outputs:
-  maven_repo_url:
-    description: 'The Maven repository root URL used to download the distribution'
-    value: ${{ steps.get_repo_url.outputs.repo_url }}
+  download_url:
+    description: 'The URL used to download the distribution'
+    value: ${{ steps.download.outputs.url }}
   output_file:
     description: 'Path to the downloaded file'
     value: ${{ steps.derive-output-file.outputs.file }}
 runs:
   using: "composite"
   steps:
-    - name: Get repository URL
-      id: get_repo_url
+    - name: Derive repositories
+      id: derive-repositories
       shell: bash
       run: |
         . ${GITHUB_ACTION_PATH}/../.github/scripts/logging.functions.sh
 
-        # Pick an appropriate key from "repo-vars-as-json"
-        case "${DISTRIBUTION}" in
-            "hazelcast")
-              if [[ "${HZ_VERSION}" == *"SNAPSHOT"* ]]; then
-                repo_var_name=MAVEN_OSS_SNAPSHOT_REPO
-              else
-                repo_var_name=MAVEN_OSS_RELEASE_REPO
-              fi
+        case "${ENVIRONMENT}" in
+          live)
+            repos=$(cat <<'EOF'
+        https://repo.maven.apache.org/maven2
+        https://repository.hazelcast.com/release
+        https://repository.hazelcast.com/snapshot
+        https://repository.hazelcast.com/snapshot-internal
+        EOF
+        )
             ;;
-            "hazelcast-enterprise")
-              if [[ "${HZ_VERSION}" == *"SNAPSHOT"* ]]; then
-                repo_var_name=MAVEN_EE_SNAPSHOT_REPO
-              else
-                repo_var_name=MAVEN_EE_RELEASE_REPO
-              fi
+          sandbox)
+            repos=$(cat <<'EOF'
+        https://repository.hazelcast.com/sandbox-mvn-prod
+        EOF
+        )
             ;;
-            *)
-            echoerr "Unsupported distribution type '${DISTRIBUTION}'" ; return 1
+          *)
+            echoerr "Unsupported environment (${ENVIRONMENT})" ; exit 1
             ;;
         esac
 
-        # Lookup up the value of the selected key in "repo-vars-as-json"
-        REPO_URL=$(jq --raw-output .${repo_var_name} <<< "${REPO_VARS_AS_JSON}")
-        echo "repo_url=${REPO_URL}" >> ${GITHUB_OUTPUT}
-
-        # Detect if the repo definition specifies authentication via a Maven server (e.g. "my-private-repo::::https://example.com/private-repo")
-        if [[ "${REPO_URL}" == *[!:]::::* ]]; then
-          echo "authentication-required=true" >> ${GITHUB_OUTPUT}
-        fi
+        {
+          echo "repositories<<EOF"
+          echo "${repos}"
+          echo "EOF"
+        } >> ${GITHUB_OUTPUT}
       env:
-        REPO_VARS_AS_JSON: ${{ inputs.repo-vars-as-json }}
-        DISTRIBUTION: ${{ inputs.distribution }}
-        HZ_VERSION: ${{ inputs.hz_version }}
+        ENVIRONMENT: ${{ inputs.environment }}
 
-      # Should be a relative local path, but doesn't resolve when called from another repo
-    - uses: hazelcast/docker-actions/setup-maven-snapshot-internal@master
-      if: ${{ steps.get_repo_url.outputs.authentication-required == 'true' }}
+    - uses: hazelcast/docker-actions/get-jfrog-credentials@master
+      id: jfrog
       with:
         aws-role-to-assume: ${{ inputs.aws-role-to-assume }}
-        maven-settings-path: ${{ inputs.maven-settings-path }}
+        jfrog-oidc-provider-name: ${{ github.repository_owner }}-snapshot-internal
 
     - name: Derive output file
       id: derive-output-file
@@ -89,23 +82,42 @@ runs:
       env:
         FILE: ${{ inputs.output_file || format('distribution.{0}', inputs.packaging) }}
 
-    - name: Download via Maven
+    - name: Download
+      id: download
       shell: bash
       run: |
-        mvn \
-          org.apache.maven.plugins:maven-dependency-plugin:2.10:get \
-          -DremoteRepositories="${{ steps.get_repo_url.outputs.repo_url }}" \
-          -DgroupId="com.hazelcast" \
-          -DartifactId="${DISTRIBUTION}-distribution" \
-          -Dversion="${HZ_VERSION}" \
-          -Dclassifier="${CLASSIFIER}" \
-          -Dpackaging="${PACKAGING}" \
-          -Dtransitive=false \
-          -Ddest="${{ steps.derive-output-file.outputs.file }}" \
-          --batch-mode \
-          --no-transfer-progress
+        . ${GITHUB_ACTION_PATH}/../.github/scripts/logging.functions.sh
+
+        while IFS= read -r repository; do
+          url="${repository%/}/com/hazelcast/${ARTIFACT_ID}/${VERSION}/${ARTIFACT_ID}-${VERSION}${CLASSIFIER:+-$CLASSIFIER}.${PACKAGING}"
+
+          curl_args=(
+            --fail
+            --location
+            --output "${{ steps.derive-output-file.outputs.file }}"
+            --show-error
+            --silent
+          )
+
+          if [[ "${repository}" == *repository.hazelcast.com* ]]; then
+            curl_args+=(--user "${{ steps.jfrog.outputs.user }}:${{ steps.jfrog.outputs.token }}")
+          fi
+
+          echodebug "Downloading from ${url}..."
+
+          if curl "${curl_args[@]}" "${url}"; then
+            echodebug "Downloaded from ${url}"
+            echo "url=${url}" >> ${GITHUB_OUTPUT}
+            exit 0
+          else
+            echodebug "Failed to download from ${url}"
+          fi
+        done <<< "${{ steps.derive-repositories.outputs.repositories }}"
+
+        echoerr "Distribution not found in ${{ steps.derive-repositories.outputs.repositories }}"
+        exit 1
       env:
-        DISTRIBUTION: ${{ inputs.distribution }}
-        HZ_VERSION: ${{ inputs.hz_version }}
+        ARTIFACT_ID: ${{ inputs.distribution }}-distribution
+        VERSION: ${{ inputs.hz_version }}
         CLASSIFIER: ${{ inputs.classifier }}
         PACKAGING: ${{ inputs.packaging }}

--- a/get-supported-platforms/action.yml
+++ b/get-supported-platforms/action.yml
@@ -34,7 +34,7 @@ runs:
               echo "platforms=linux/arm64,linux/amd64,linux/s390x,linux/ppc64le" >> ${GITHUB_OUTPUT}
             ;;
             *)
-            echoerr "Unsupported platform behaviour for ${base_image_name}" ; return 1
+            echoerr "Unsupported platform behaviour for ${base_image_name}" ; exit 1
             ;;
         esac
       env:

--- a/get-supported-platforms/action.yml
+++ b/get-supported-platforms/action.yml
@@ -34,7 +34,8 @@ runs:
               echo "platforms=linux/arm64,linux/amd64,linux/s390x,linux/ppc64le" >> ${GITHUB_OUTPUT}
             ;;
             *)
-            echoerr "Unsupported platform behaviour for ${base_image_name}" ; exit 1
+            echoerr "Unsupported platform behaviour for ${base_image_name}"
+            exit 1
             ;;
         esac
       env:


### PR DESCRIPTION
As part of the groundwork to support [DI-730](https://hazelcast.atlassian.net/browse/DI-730), improve `download-hz-dist`:
- support multiple repositories
   - currently it only supports a single repository at a time, hence we have to supply a repository for _each_ configuration (release/`SNAPSHOT`/OSS/EE etc)
   - it would be better to supply a set of repositories and have it figure out where to find the artifact
- centralise repositories
   - the repository configuration in `hazelcast-docker` and `hazelcast-packaging` is duplicated in each GitHub repo environment
   - it would be better if this was in a single place
   - passing all the repo vars is messy
- migrate away from a deprecated `maven-dependency-plugin`
   - replace `mvn` with `curl`
   - see [DI-663](https://hazelcast.atlassian.net/browse/DI-663)

[DI-730]: https://hazelcast.atlassian.net/browse/DI-730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DI-663]: https://hazelcast.atlassian.net/browse/DI-663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ