### PR TITLE
Ensure `fail` option used with curl to catch errors

### DIFF
--- a/.github/scripts/logging.functions.sh
+++ b/.github/scripts/logging.functions.sh
@@ -1,2 +1,2 @@
 # Delegate to "github-actions-common-scripts" implementation
-source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"

--- a/.github/workflows/test-check-base-images.yml
+++ b/.github/workflows/test-check-base-images.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Test
         run: |
           set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
-          source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
           TESTS_RESULT=0
           

--- a/.github/workflows/test-check-if-latest-lts-release.yml
+++ b/.github/workflows/test-check-if-latest-lts-release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Test
         run: |
           set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
-          source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
           TESTS_RESULT=0
           

--- a/.github/workflows/test-get-hz-versions.yml
+++ b/.github/workflows/test-get-hz-versions.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Test
         run: |
           set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
-          source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
           TESTS_RESULT=0
           

--- a/.github/workflows/test-get-jfrog-credentials.yml
+++ b/.github/workflows/test-get-jfrog-credentials.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Test
         run: |
           set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
-          source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
           TESTS_RESULT=0
           

--- a/.github/workflows/test-get-supported-jdks.yml
+++ b/.github/workflows/test-get-supported-jdks.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Test
         run: |
           set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
-          source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
           assert_eq \
             "${EXPECTED_JDKS}" \

--- a/.github/workflows/test-get-supported-platforms.yml
+++ b/.github/workflows/test-get-supported-platforms.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Test
         run: |
           set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
-          source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
           TESTS_RESULT=0
           

--- a/.github/workflows/test-resolve-editions.yml
+++ b/.github/workflows/test-resolve-editions.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Test
         run: |
           set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
-          source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
           TESTS_RESULT=0
           

--- a/assert-image-size/assert-image-size.functions_tests.sh
+++ b/assert-image-size/assert-image-size.functions_tests.sh
@@ -5,7 +5,7 @@ set -eu ${RUNNER_DEBUG:+-x}
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 . "$SCRIPT_DIR"/assert-image-size.functions.sh
 

--- a/check-base-images/check-base-images.functions_tests.sh
+++ b/check-base-images/check-base-images.functions_tests.sh
@@ -5,7 +5,7 @@ set -eu ${RUNNER_DEBUG:+-x}
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 . "$SCRIPT_DIR"/check-base-images.functions.sh
 

--- a/check-if-latest-lts-release/action.yml
+++ b/check-if-latest-lts-release/action.yml
@@ -18,11 +18,11 @@ runs:
         set -euo pipefail ${RUNNER_DEBUG:+-x}
 
         source ${GITHUB_ACTION_PATH}/../.github/scripts/logging.functions.sh
-        source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/refs/heads/master/.github/scripts/version.functions.sh)"
+        source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/hazelcast-docker/refs/heads/master/.github/scripts/version.functions.sh)"
 
         # Pull metadata from 'hazelcast' repo
         major_minor_lts_version=$( \
-          curl --silent https://raw.githubusercontent.com/hazelcast/hazelcast/refs/heads/master/hazelcast-parent/pom.xml | \
+          curl --fail --silent https://raw.githubusercontent.com/hazelcast/hazelcast/refs/heads/master/hazelcast-parent/pom.xml | \
           awk -F'[<>]' '/<hazelcast.lts.version>/ { print $3 }' \
         )
 

--- a/check-redhat-service-status/action.yml
+++ b/check-redhat-service-status/action.yml
@@ -8,10 +8,10 @@ runs:
         . ${GITHUB_ACTION_PATH}/../.github/scripts/logging.functions.sh
 
         # https://status.redhat.com/api
-        STATUS=$(curl --silent https://status.redhat.com/api/v2/status.json)
+        STATUS=$(curl --fail --silent https://status.redhat.com/api/v2/status.json)
 
         if jq --exit-status '.status.indicator != "none"' <<< "${STATUS}"; then
           echoerr "❌ RedHat service status"
           echoerr "$(jq '.status' <<< ${STATUS})"
-          echoerr "$(curl --silent https://status.redhat.com/api/v2/incidents/unresolved.json | jq)"
+          echoerr "$(curl --fail --silent https://status.redhat.com/api/v2/incidents/unresolved.json | jq)"
         fi

--- a/resolve-editions/build.functions_tests.sh
+++ b/resolve-editions/build.functions_tests.sh
@@ -5,7 +5,7 @@ set -eu ${RUNNER_DEBUG:+-x}
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 . "$SCRIPT_DIR"/build.functions.sh
 

--- a/verify-docker-reproducibility/verify-docker-reproducibility_tests.sh
+++ b/verify-docker-reproducibility/verify-docker-reproducibility_tests.sh
@@ -5,7 +5,7 @@ set -eu ${RUNNER_DEBUG:+-x}
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 TESTS_RESULT=0
 


### PR DESCRIPTION
By default, curl returns a `0` exit code even in the case of 404 errors.

This means that errors like the one in https://github.com/hazelcast/hazelcast-mono/pull/7091 are tricky to spot. It would be better if we used the [`fail` option](https://curl.se/docs/manpage.html#--fail) to ensure the failure is visible.