### PR TITLE
Re-order download URLs in `download-hz-dist`

### DIFF
--- a/download-hz-dist/action.yml
+++ b/download-hz-dist/action.yml
@@ -43,17 +43,17 @@ runs:
           live)
             repos=$(cat <<'EOF'
         https://repo.maven.apache.org/maven2
-        https://repository.hazelcast.com/live-mvn-preprod
         https://repository.hazelcast.com/release
         https://repository.hazelcast.com/snapshot
         https://repository.hazelcast.com/snapshot-internal
+        https://repository.hazelcast.com/live-mvn-preprod
         EOF
         )
             ;;
           sandbox)
             repos=$(cat <<'EOF'
-        https://repository.hazelcast.com/sandbox-mvn-preprod
         https://repository.hazelcast.com/sandbox-mvn-prod
+        https://repository.hazelcast.com/sandbox-mvn-preprod
         EOF
         )
             ;;


### PR DESCRIPTION
For Docker/packaging we download the Hazelcast distribution from a list of repositories - we only expect _one_ of the repositories to actually contain the file so the order isn't important - so for consistency, were done alphabetically.

However, we _temporarily_ push to both live and preprod separately as a transient step - and our builds are not reproducible, which means the content differs.

This causes an issue with Homebrew - the artifact downloaded from preprod has a different checksum from the artifact that will actually be installed when released.

As this is a temporary step, the easiest solution is simply to re-order the steps - checking the live repos _before_ preprod so that in this case the downloaded ZIP used for checksum calculation will be from live and therefore match when released, until such point that this duplication is removed and the same artifact is ultimately pushed to pre-prod and then promoted to live.