### PR TITLE
Remove `get-jfrog-credentials` `url` output [DI-844]

### DIFF
--- a/.github/workflows/test-check-if-latest-lts-release.yml
+++ b/.github/workflows/test-check-if-latest-lts-release.yml
@@ -24,11 +24,11 @@ jobs:
         with:
           hz_version: 5.5.0
 
-      - name: Run check-if-latest-lts-release 5.5.9
-        id: check-if-latest-lts-release-5_5_9
+      - name: Run check-if-latest-lts-release 5.5.10
+        id: check-if-latest-lts-release-5_5_10
         uses: ./docker-actions/check-if-latest-lts-release
         with:
-          hz_version: 5.5.9
+          hz_version: 5.5.10
 
       - name: Run check-if-latest-lts-release 5.6.0
         id: check-if-latest-lts-release-5_6_0
@@ -51,7 +51,7 @@ jobs:
           }
 
           assert_equals "false" "${{ steps.check-if-latest-lts-release-5_5_0.outputs.is_latest_lts }}"
-          assert_equals "true" "${{ steps.check-if-latest-lts-release-5_5_9.outputs.is_latest_lts }}"
+          assert_equals "true" "${{ steps.check-if-latest-lts-release-5_5_10.outputs.is_latest_lts }}"
           assert_equals "false" "${{ steps.check-if-latest-lts-release-5_6_0.outputs.is_latest_lts }}"
 
           assert_eq 0 "$TESTS_RESULT" "All tests should pass"

--- a/.github/workflows/test-get-jfrog-credentials.yml
+++ b/.github/workflows/test-get-jfrog-credentials.yml
@@ -38,7 +38,6 @@ jobs:
             assert_not_empty "${actual}" "$msg" && log_success "${msg}" || TESTS_RESULT=$?
           }
 
-          assert "${{ steps.jfrog.outputs.url }}" "url"
           assert "${{ steps.jfrog.outputs.user }}" "user"
           assert "${{ steps.jfrog.outputs.token }}" "token"
 

--- a/get-jfrog-credentials/action.yml
+++ b/get-jfrog-credentials/action.yml
@@ -7,8 +7,6 @@ inputs:
     description: 'JFrog provider to authenticate against'
     required: true
 outputs:
-  url:
-    value: ${{ steps.get-url.outputs.url }}
   user:
     value: ${{ steps.jfrog.outputs.oidc-user }}
   token:


### PR DESCRIPTION
The output is confusing (it's a domain name, not a URL) and exposes an internal URL - in all cases, an external URL can be used that's easier instead.

Fixes: [DI-844](https://hazelcast.atlassian.net/browse/DI-844)

[DI-844]: https://hazelcast.atlassian.net/browse/DI-844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ