### PR TITLE
Fix PR Builder post `5.5.10` release

### DIFF
--- a/.github/workflows/test-check-if-latest-lts-release.yml
+++ b/.github/workflows/test-check-if-latest-lts-release.yml
@@ -24,11 +24,11 @@ jobs:
         with:
           hz_version: 5.5.0
 
-      - name: Run check-if-latest-lts-release 5.5.9
-        id: check-if-latest-lts-release-5_5_9
+      - name: Run check-if-latest-lts-release 5.5.10
+        id: check-if-latest-lts-release-5_5_10
         uses: ./docker-actions/check-if-latest-lts-release
         with:
-          hz_version: 5.5.9
+          hz_version: 5.5.10
 
       - name: Run check-if-latest-lts-release 5.6.0
         id: check-if-latest-lts-release-5_6_0
@@ -51,7 +51,7 @@ jobs:
           }
 
           assert_equals "false" "${{ steps.check-if-latest-lts-release-5_5_0.outputs.is_latest_lts }}"
-          assert_equals "true" "${{ steps.check-if-latest-lts-release-5_5_9.outputs.is_latest_lts }}"
+          assert_equals "true" "${{ steps.check-if-latest-lts-release-5_5_10.outputs.is_latest_lts }}"
           assert_equals "false" "${{ steps.check-if-latest-lts-release-5_6_0.outputs.is_latest_lts }}"
 
           assert_eq 0 "$TESTS_RESULT" "All tests should pass"


### PR DESCRIPTION
Tests assume `5.5.9` is latest LTS which is no longer case since `5.5.10` release.