### PR TITLE
Require explicit `status` input for Slack notification action

### DIFF
--- a/slack-notification/action.yml
+++ b/slack-notification/action.yml
@@ -7,8 +7,8 @@ inputs:
     description: Slack channel to send the notification to
     default: "#hazelcast-docker-notifications"
   status:
-    description: The status to set, otherwise inherited from the enclosing job
-    required: false
+    description: The status to set (`success` or `failure`)
+    required: true
 runs:
   using: "composite"
   steps:
@@ -25,7 +25,7 @@ runs:
           echo "text=❌ \`${GITHUB_WORKFLOW}\` (\`${GITHUB_WORKFLOW_REF}\`) - ${STATUS}\n${JOB_URL}" >> ${GITHUB_OUTPUT}
         fi
       env:
-        STATUS: ${{ inputs.status || job.status }}
+        STATUS: ${{ inputs.status }}
 
     - uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
       with:


### PR DESCRIPTION
The workflow attempts to derive the enclosing job status, to report success/failure without being explicitly told.

However, this doesn't seem to work properly, e.g. in this example, it's only triggered on `failure()`: https://github.com/hazelcast/mono-actions/blob/f4d06085c5c0089ad76a475e067a4fc096adab25/copybara/copy-commit-to-os/action.yaml#L88-89

And yet the [job logs](https://github.com/hazelcast/hazelcast-mono/actions/runs/29821335563/job/88623379973#step:3:1549) show the `job.status` as `success`.

https://github.com/actions/runner/issues/1682 relates to a _similar_ issue where it's suggested the status is not always updated "live" in composite actions.

The simplest solution is to require an _explicit_ input rather than deriving.